### PR TITLE
plugin to use relay for extra zone

### DIFF
--- a/zone8_relay/zone8_relay.manifest
+++ b/zone8_relay/zone8_relay.manifest
@@ -1,0 +1,12 @@
+Description: An plugin to use the on-board OSPi relay for an 8th zone 
+Copyright 2015
+Author: Greg
+Email: greglarious@gmail.com
+License: GNU GPL 3.0
+
+Requirements: none
+
+##### List all plugin files below preceded by a blank line [file_name.ext path] relative to OSPi directory #####
+
+zone8_relay.py plugins
+zone8_relay.manifest plugins/manifests

--- a/zone8_relay/zone8_relay.py
+++ b/zone8_relay/zone8_relay.py
@@ -6,12 +6,14 @@ from gpio_pins import GPIO
 import gv
 
 def notify_zone_change(name, **kw):
-    if gv.srvals[8] == 1:
-       #print "zone 9 is on"
-       GPIO.output(10, GPIO.HIGH)
-    else:
-       #print "zone 9 is off"
-       GPIO.output(10, GPIO.LOW)
+    relayGPIO = 10 
+    targetZone = 8
+
+    if len(gv.srvals) >= targetZone:
+        if gv.srvals[targetZone] == 1:
+            GPIO.output(relayGPIO, GPIO.HIGH)
+        else:
+            GPIO.output(relayGPIO, GPIO.LOW)
 
 zones = signal('zone_change')
 zones.connect(notify_zone_change)

--- a/zone8_relay/zone8_relay.py
+++ b/zone8_relay/zone8_relay.py
@@ -1,0 +1,17 @@
+# !/usr/bin/env python
+#  This plugin includes implements an 8th zone using the relay on gpio 10
+
+from blinker import signal
+from gpio_pins import GPIO
+import gv
+
+def notify_zone_change(name, **kw):
+    if gv.srvals[8] == 1:
+       #print "zone 9 is on"
+       GPIO.output(10, GPIO.HIGH)
+    else:
+       #print "zone 9 is off"
+       GPIO.output(10, GPIO.LOW)
+
+zones = signal('zone_change')
+zones.connect(notify_zone_change)


### PR DESCRIPTION
setup:
- assumes a 9th zone is configured
- assumes you have wired the onboard relay to send voltage to a sprinkler solenoid

this plugin watches for activity on that 9th zone and send the gpio signals to the relay.
