### PR TITLE
A suite of MQTT plugins for SIP

### DIFF
--- a/mqtt/mqtt.html
+++ b/mqtt/mqtt.html
@@ -1,0 +1,61 @@
+$def with(settings, client_id, error_msg)
+<!-- Edit: Replace "proto_vals" with settings values for your plugin if used-->
+
+$var title: $_('SIP MQTT Plugin')
+$var page: mqtt_plugin
+<script>
+
+    // Initialize behaviors
+    jQuery(document).ready(function(){
+
+        jQuery("#cSubmit").click(function() {
+            jQuery("#pluginForm").submit();
+        });
+        jQuery("button#cCancel").click(function(){
+            window.location= baseUrl + "/";
+        });
+    });
+</script>
+
+<div id="plugin">
+    <div class="title">MQTT Plugin</div>
+    <div>
+    <p>MQTT plugin adds an MQTT client to the SIP daemon for other plugins to use to publish information and / or
+      receive commands over MQTT. On this page, the shared client is configured.</p>
+    <p>Having a shared MQTT client simplifies configuration and lowers overhead on the SIP process, network and broker.
+    </p>
+    </div>
+
+    <div id="errorMessage">${error_msg}</div>
+
+    <form id="pluginForm" action="${app_path('/mqtt-save')}" method="get"> <!--Edit: Replace "proto-save" with URL of plugin's class for saving settings-->
+
+        <table class="optionList">
+
+            <!--Text fields-->
+            <tr>
+                <td style='text-transform: none;'>$_('MQTT Broker Host'):</td>
+                <td><input type="text" name="broker_host" value="${settings['broker_host']}"></td>
+            </tr>
+            <tr>
+                <td style='text-transform: none;'>$_('MQTT Broker Port'):</td>
+                <td><input type="text" name="broker_port" value="${settings['broker_port']}"></td>
+            </tr>
+            <tr>
+              <td style='text-transform: none;'>$_('MQTT Publish up/down topic'):</td>
+              <td><input type="text" name="publish_up_down" value="${settings['publish_up_down']}">
+              Leave blank to not publish SIP status.</td>
+            </tr>
+            <tr>
+                <td style='text-transform: none;'>$_('MQTT Client ID'):</td>  <!--Edit-->
+                <td>${client_id}</td>
+            </tr>
+        </table>
+
+    </form>
+
+<div id="controls">
+    <button id="cSubmit" class="submit"><b>$_('Submit')</b></button>
+    <button id="cCancel" class="cancel danger">$_('Cancel')</button>
+</div>
+</div>

--- a/mqtt/mqtt.manifest
+++ b/mqtt/mqtt.manifest
@@ -1,0 +1,14 @@
+Description: A plugin which adds a shared MQTT client to SIP
+Copyright 2016
+Author: Daniel Casner
+Email: daniel@danielcasner.org
+License: GNU GPL 3.0
+
+Requirements: none
+
+##### List all plugin files below preceded by a blank line [file_name.ext path] relative to OSPi directory #####
+
+mqtt.py plugins
+mqtt.html templates
+mqtt.json data (generated)
+mqtt.manifest plugins/manifests

--- a/mqtt/mqtt.py
+++ b/mqtt/mqtt.py
@@ -1,0 +1,138 @@
+# !/usr/bin/env python
+from __future__ import print_function
+""" SIP plugin adds an MQTT client to SIP for other plugins to broadcast and receive via MQTT
+The intent is to facilitate joining SIP to larger automation systems
+"""
+__author__ = "Daniel Casner <daniel@danielcasner.org>"
+
+import web  # web.py framework
+import gv  # Get access to SIP's settings
+from urls import urls  # Get access to SIP's URLs
+from sip import template_render  #  Needed for working with web.py templates
+from webpages import ProtectedPage  # Needed for security
+import json  # for working with data file
+import atexit # For publishing down message
+try:
+    import paho.mqtt.client as mqtt
+except ImportError:
+    print("ERROR: MQTT Plugin requires paho mqtt.")
+    print("\ttry: pip install paho-mqtt")
+    mqtt = None
+
+DATA_FILE = "./data/mqtt.json"
+
+_client = None
+_settings = {
+    'broker_host': 'localhost',
+    'broker_port': 1883,
+    'publish_up_down': ''
+}
+_subscriptions = {}
+
+# Add new URLs to access classes in this plugin.
+urls.extend([
+    '/mqtt-sp', 'plugins.mqtt.settings',
+    '/mqtt-save', 'plugins.mqtt.save_settings'
+    ])
+gv.plugin_menu.append(['MQTT', '/mqtt-sp'])
+
+NO_MQTT_ERROR = "MQTT plugin requires paho mqtt python library. On the command line run `pip install paho-mqtt` and restart SIP to get it."
+
+class settings(ProtectedPage):
+    """Load an html page for entering plugin settings.
+    """
+    def GET(self):
+        settings = get_settings()
+        return template_render.mqtt(settings, gv.sd[u'name'], NO_MQTT_ERROR if mqtt is None else "")  # open settings page
+
+class save_settings(ProtectedPage):
+    """Save user input to json file.
+    Will create or update file when SUBMIT button is clicked
+    CheckBoxes only appear in qdict if they are checked.
+    """
+
+    def GET(self):
+        qdict = web.input()  # Dictionary of values returned as query string from settings page.
+        with open(DATA_FILE, 'w') as f:
+            try:
+                port = int(qdict['broker_port'])
+                assert port > 80 and port < 65535
+                _settings['broker_port'] = port
+                _settings['broker_host'] = qdict['broker_host']
+                _settings['publish_up_down'] = qdict['publish_up_down']
+            except:
+                return template_render.proto(qdict, gv.sd[u'name'], "Broker port must be a valid integer port number")
+            else:
+                json.dump(_settings, f) # save to file
+                publish_status()
+        raise web.seeother('/')  # Return user to home page.
+
+def get_settings():
+    global _settings
+    try:
+        fh = open(DATA_FILE, 'r')
+        try:
+            _settings = json.load(fh)
+        except ValueError as e:
+            print("MQTT pluging couldn't parse data file:", e)
+        finally:
+            fh.close()
+    except IOError as e:
+        print("MQTT Plugin couldn't open data file:", e)
+    return _settings
+
+def on_message(client, userdata, msg):
+    "Callback for MQTT data recieved"
+    global _subscriptions
+    if not msg.topic in _subscriptions:
+        print("MQTT plugin got unexpected message on topic:", msg.topic)
+    else:
+        for cb in _subscriptions[msg.topic]:
+            cb(client, msg)
+
+def get_client():
+    global _client
+    if _client is None and mqtt is not None:
+        try:
+            _client = mqtt.Client(gv.sd[u'name']) # Use system name as client ID
+            _client.on_message = on_message
+            _client.connect(_settings['broker_host'], _settings['broker_port'])
+            if _settings['publish_up_down']:
+                _client.will_set(_settings['publish_up_down'], json.dumps("DIED"), qos=1, retain=True)
+            _client.loop_start()
+        except Exception as e:
+            print("MQTT plugin couldn't initalize client:", e)
+    return _client
+
+def publish_status(status="UP"):
+    global _settings
+    if _settings['publish_up_down']:
+        print("MQTT publish", status)
+        client = get_client()
+        if client:
+            client.publish(_settings['publish_up_down'], json.dumps(status), qos=1, retain=True)
+
+def subscribe(topic, callback, qos=0):
+    "Subscribes to a topic with the given callback"
+    global _subscriptions
+    client = get_client()
+    if client:
+        if topic not in _subscriptions:
+            _subscriptions[topic] = [callback]
+            client.subscribe(topic, qos)
+        else:
+            _subscriptions[topic].append(callback)
+
+def on_restart():
+    global _client
+    if _client is not None:
+        publish_status("DOWN")
+        _client.disconnect()
+        _client.loop_stop()
+        _client = None
+
+atexit.register(on_restart)
+
+get_settings()
+
+publish_status()

--- a/mqtt_schedule/mqtt_schedule.html
+++ b/mqtt_schedule/mqtt_schedule.html
@@ -1,0 +1,46 @@
+$def with(schedule_topic, error_msg)
+
+$var title: $_('SIP MQTT Schedule Plugin')
+$var page: mqtt_plugin
+<script>
+
+    // Initialize behaviors
+    jQuery(document).ready(function(){
+
+        jQuery("#cSubmit").click(function() {
+            jQuery("#pluginForm").submit();
+        });
+        jQuery("button#cCancel").click(function(){
+            window.location= baseUrl + "/";
+        });
+    });
+</script>
+
+<div id="plugin">
+    <div class="title">MQTT Schedule Plugin</div>
+    <div>
+    <p>Relies on the base MQTT plugin, allows runonce programs to be set over MQTT.
+    </p>
+    </div>
+
+    <div id="errorMessage">${error_msg}</div>
+
+    <form id="pluginForm" action="${app_path('/mr1-save')}" method="get"> <!--Edit: Replace "proto-save" with URL of plugin's class for saving settings-->
+
+        <table class="optionList">
+
+            <!--Text fields-->
+            <tr>
+                <td style='text-transform: none;'>$_('Scheduling topic'):</td>
+                <td>The topic subscribe to for run once commands.<br />
+                  <input type="text" name="schedule_topic" value="${schedule_topic}">
+                </td>
+            </tr>
+        </table>
+    </form>
+
+<div id="controls">
+    <button id="cSubmit" class="submit"><b>$_('Submit')</b></button>
+    <button id="cCancel" class="cancel danger">$_('Cancel')</button>
+</div>
+</div>

--- a/mqtt_schedule/mqtt_schedule.manifest
+++ b/mqtt_schedule/mqtt_schedule.manifest
@@ -1,0 +1,13 @@
+Description: Uses mqtt plugin and allows run once programs to be scheduled over MQTT
+Copyright 2016
+Author: Daniel Casner
+Email: daniel@danielcasner.org
+License: GNU GPL 3.0
+
+Requirements: mqtt
+
+##### List all plugin files below preceded by a blank line [file_name.ext path] relative to OSPi directory #####
+
+mqtt_schedule.py plugins
+mqtt_schedule.html templates
+mqtt_schedule.manifest plugins/manifests

--- a/mqtt_schedule/mqtt_schedule.py
+++ b/mqtt_schedule/mqtt_schedule.py
@@ -1,0 +1,101 @@
+# !/usr/bin/env python
+from __future__ import print_function
+""" SIP plugin uses mqtt plugin to receive run once program commands over MQTT
+"""
+__author__ = "Daniel Casner <daniel@danielcasner.org>"
+
+import web  # web.py framework
+import gv  # Get access to SIP's settings
+from urls import urls  # Get access to SIP's URLs
+from sip import template_render  #  Needed for working with web.py templates
+from webpages import ProtectedPage  # Needed for security
+from blinker import signal # To receive station notifications
+from helpers import schedule_stations
+import json  # for working with data file
+from plugins import mqtt
+
+# Add new URLs to access classes in this plugin.
+urls.extend([
+    '/mr1-sp', 'plugins.mqtt_schedule.settings',
+    '/mr1-save', 'plugins.mqtt_schedule.save_settings'
+    ])
+gv.plugin_menu.append(['MQTT scheduler', '/mr1-sp'])
+
+class settings(ProtectedPage):
+    """Load an html page for entering plugin settings.
+    """
+    def GET(self):
+        settings = mqtt.get_settings()
+        zone_topic = settings.get('schedule_topic', gv.sd[u'name'] + '/schedule')
+        return template_render.mqtt_schedule(zone_topic, "")  # open settings page
+
+class save_settings(ProtectedPage):
+    """Save user input to json file.
+    Will create or update file when SUBMIT button is clicked
+    CheckBoxes only appear in qdict if they are checked.
+    """
+    def GET(self):
+        qdict = web.input()  # Dictionary of values returned as query string from settings page.
+        settings = mqtt.get_settings()
+        settings.update(qdict)
+        with open(mqtt.DATA_FILE, 'w') as f:
+            json.dump(settings, f) # save to file
+        subscribe()
+        raise web.seeother('/')  # Return user to home page.
+
+def on_message(client, msg):
+    "Callback when MQTT message is received."
+    if not gv.sd['en']: # check operation status
+        return
+    num_brds = gv.sd['nbrd']
+    num_sta  = num_brds * 8
+    try:
+        cmd = json.loads(msg.payload)
+    except ValueError as e:
+        print("MQTT Schedule could not decode command: ", msg.payload, e)
+        return
+    if type(cmd) is list:
+        if len(cmd) < num_sta:
+            print("MQTT schedule, not enough stations specified, assuming first {} of {}".format(len(cmd), num_sta))
+            rovals = cmd + ([0] * (num_sta - len(cmd)))
+        elif len(cmd) > num_sta:
+            print("MQTT schedule, too many stations specified, truncating to {}".format(num_sta))
+            rovals = cmd[0:num_sta]
+        else:
+            rovals = cmd
+    elif type(cmd) is dict:
+        rovals = [0] * num_sta
+        for k, v in cmd.items():
+            if k not in gv.snames:
+                print("MQTT schedule, no station named:", k)
+            else:
+                rovals[gv.snames.index(k)] = v
+    else:
+        print("MQTT schedule unexpected command: ", msg.payload)
+        return
+    if any(rovals):
+        print("MQTT schedule:", rovals)
+        gv.rovals = rovals
+        stations = [0] * num_brds
+        gv.ps = []  # program schedule (for display)
+        gv.rs = []  # run schedule
+        for i in range(gv.sd['nst']):
+            gv.ps.append([0, 0])
+            gv.rs.append([0, 0, 0, 0])
+        for i, v in enumerate(gv.rovals):
+            if v:  # if this element has a value
+                gv.rs[i][0] = gv.now
+                gv.rs[i][2] = v
+                gv.rs[i][3] = 98
+                gv.ps[i][0] = 98
+                gv.ps[i][1] = v
+                stations[i / 8] += 2 ** (i % 8)
+        schedule_stations(stations)
+
+def subscribe():
+    "Subscribe to messages"
+    topic = mqtt.get_settings().get('schedule_topic')
+    if topic:
+        mqtt.subscribe(topic, on_message, 2)
+
+subscribe()

--- a/mqtt_zones/mqtt_zones.html
+++ b/mqtt_zones/mqtt_zones.html
@@ -1,0 +1,47 @@
+$def with(zone_topic, error_msg)
+<!-- Edit: Replace "proto_vals" with settings values for your plugin if used-->
+
+$var title: $_('SIP MQTT Zones Plugin')
+$var page: mqtt_plugin
+<script>
+
+    // Initialize behaviors
+    jQuery(document).ready(function(){
+
+        jQuery("#cSubmit").click(function() {
+            jQuery("#pluginForm").submit();
+        });
+        jQuery("button#cCancel").click(function(){
+            window.location= baseUrl + "/";
+        });
+    });
+</script>
+
+<div id="plugin">
+    <div class="title">MQTT Zones Plugin</div>
+    <div>
+    <p>Relies on the base MQTT plugin and broadcasts zone changes over MQTT
+    </p>
+    </div>
+
+    <div id="errorMessage">${error_msg}</div>
+
+    <form id="pluginForm" action="${app_path('/zone2mqtt-save')}" method="get"> <!--Edit: Replace "proto-save" with URL of plugin's class for saving settings-->
+
+        <table class="optionList">
+
+            <!--Text fields-->
+            <tr>
+                <td style='text-transform: none;'>$_('Zone topic'):</td>
+                <td>The topic to broadcast zone updates on<br />
+                  <input type="text" name="zone_topic" value="${zone_topic}">
+                </td>
+            </tr>
+        </table>
+    </form>
+
+<div id="controls">
+    <button id="cSubmit" class="submit"><b>$_('Submit')</b></button>
+    <button id="cCancel" class="cancel danger">$_('Cancel')</button>
+</div>
+</div>

--- a/mqtt_zones/mqtt_zones.manifest
+++ b/mqtt_zones/mqtt_zones.manifest
@@ -1,0 +1,13 @@
+Description: Uses MQTT plugin and broadcasts zone status information
+Copyright 2016
+Author: Daniel Casner
+Email: daniel@danielcasner.org
+License: GNU GPL 3.0
+
+Requirements: mqtt
+
+##### List all plugin files below preceded by a blank line [file_name.ext path] relative to OSPi directory #####
+
+mqtt_zones.py plugins
+mqtt_zones.html templates
+mqtt_zones.manifest plugins/manifests

--- a/mqtt_zones/mqtt_zones.py
+++ b/mqtt_zones/mqtt_zones.py
@@ -1,0 +1,61 @@
+# !/usr/bin/env python
+from __future__ import print_function
+""" SIP plugin uses mqtt plugin to broadcast station status every time it changes.
+"""
+__author__ = "Daniel Casner <daniel@danielcasner.org>"
+
+import web  # web.py framework
+import gv  # Get access to SIP's settings
+from urls import urls  # Get access to SIP's URLs
+from sip import template_render  #  Needed for working with web.py templates
+from webpages import ProtectedPage  # Needed for security
+from blinker import signal # To receive station notifications
+import json  # for working with data file
+from plugins import mqtt
+
+# Add new URLs to access classes in this plugin.
+urls.extend([
+    '/zone2mqtt-sp', 'plugins.mqtt_zones.settings',
+    '/zone2mqtt-save', 'plugins.mqtt_zones.save_settings'
+    ])
+gv.plugin_menu.append(['MQTT zone broadcaster', '/zone2mqtt-sp'])
+
+class settings(ProtectedPage):
+    """Load an html page for entering plugin settings.
+    """
+    def GET(self):
+        settings = mqtt.get_settings()
+        zone_topic = settings.get('zone_topic', gv.sd[u'name'] + '/zones')
+        return template_render.mqtt_zones(zone_topic, "")  # open settings page
+
+class save_settings(ProtectedPage):
+    """Save user input to json file.
+    Will create or update file when SUBMIT button is clicked
+    CheckBoxes only appear in qdict if they are checked.
+    """
+    def GET(self):
+        qdict = web.input()  # Dictionary of values returned as query string from settings page.
+        settings = mqtt.get_settings()
+        settings.update(qdict)
+        with open(mqtt.DATA_FILE, 'w') as f:
+            json.dump(settings, f) # save to file
+        raise web.seeother('/')  # Return user to home page.
+
+### valves ###
+def notify_zone_change(name, **kw):
+    names = gv.snames
+    mas = gv.sd['mas']
+    vals = gv.srvals
+    payload = {
+        'zone_list': vals,
+        'zone_dict': {name: status for name, status in zip(names, vals)},
+        'master_on': 0 if mas == 0 else vals[mas-1]
+    }
+    zone_topic = mqtt.get_settings().get('zone_topic')
+    if zone_topic:
+        client = mqtt.get_client()
+        if client:
+            client.publish(zone_topic, json.dumps(payload), qos=1, retain=True)
+
+zones = signal('zone_change')
+zones.connect(notify_zone_change)


### PR DESCRIPTION
I know other work has been done on integrating MQTT with SIP but I couldn't find any that had been cleanly wrapped up as plugins or did quite what I wanted so I've created a set of plugins here.

## MQTT
This is the base plugin, it exists mostly to provide a shared MQTT client object for other plugins.
Optionally it can broadcast up/down status messages when SIP starts, exits or dies.

## MQTT Zones
Relies on *MQTT* broadcasts the current status of all the zones.

## MQTT Schedule
Relies on *MQTT*, subscribes to a control topic and schedules run once programs as command by MQTT.
