### PR TITLE
Don’t run the sprinklers if the current temperature is below X degrees Celsius.

### DIFF
--- a/weather_level_adj/weather_level_adj.html
+++ b/weather_level_adj/weather_level_adj.html
@@ -19,7 +19,7 @@ $var page: plugins
 <div id="plugin">
     <div class="title">$_('Weather-based Water Level')</div>
     <p>$_('When weather-based water level is enabled, the weather will be checked every hour and the water level will be adjusted accordingly.')</p>
-    <p>$_('If the low temperature cutoff is enabled, the the sprinklers will not run when the temperature is below the set temperature.')</p>
+    <p>$_('Additionally, when the low temperature cutoff is enabled the the sprinklers will not run when the temperature at the last hourly check was below the set temperature.')</p>
     <form id="pluginForm" action="/luwa" method="get">
         <table class="optionList">
             <tr>

--- a/weather_level_adj/weather_level_adj.html
+++ b/weather_level_adj/weather_level_adj.html
@@ -19,6 +19,7 @@ $var page: plugins
 <div id="plugin">
     <div class="title">$_('Weather-based Water Level')</div>
     <p>$_('When weather-based water level is enabled, the weather will be checked every hour and the water level will be adjusted accordingly.')</p>
+    <p>$_('If the low temperature cutoff is enabled, the the sprinklers will not run when the temperature is below the set temperature.')</p>
     <form id="pluginForm" action="/luwa" method="get">
         <table class="optionList">
             <tr>
@@ -31,6 +32,18 @@ $var page: plugins
                 <td style='text-transform: none;'>$_('Min percentage'):</td>
                 <td>
                     <input name='wl_min' type='number' min="0" max="100" value=$m_vals["wl_min"]>
+                </td>
+            </tr>
+            <tr>
+                <td style='text-transform: none;'>$_('Use low temperature cutoff'):</td>
+                <td>
+                    <input name='temp_cutoff_enable' type='checkbox'${" checked" if m_vals['temp_cutoff_enable'] == "on" else ""}>
+                </td>
+            </tr>
+            <tr>
+                <td style='text-transform: none;'>$_('Low temperature cutoff in Celsius'):</td>
+                <td>
+                    <input name='temp_cutoff' type='number' min="0" max="100" value=$m_vals["temp_cutoff"]>
                 </td>
             </tr>
             <tr>

--- a/weather_level_adj/weather_level_adj.html
+++ b/weather_level_adj/weather_level_adj.html
@@ -29,12 +29,6 @@ $var page: plugins
                 </td>
             </tr>
             <tr>
-                <td style='text-transform: none;'>$_('Min percentage'):</td>
-                <td>
-                    <input name='wl_min' type='number' min="0" max="100" value=$m_vals["wl_min"]>
-                </td>
-            </tr>
-            <tr>
                 <td style='text-transform: none;'>$_('Use low temperature cutoff'):</td>
                 <td>
                     <input name='temp_cutoff_enable' type='checkbox'${" checked" if m_vals['temp_cutoff_enable'] == "on" else ""}>
@@ -44,6 +38,12 @@ $var page: plugins
                 <td style='text-transform: none;'>$_('Low temperature cutoff in Celsius'):</td>
                 <td>
                     <input name='temp_cutoff' type='number' min="0" max="100" value=$m_vals["temp_cutoff"]>
+                </td>
+            </tr>
+            <tr>
+                <td style='text-transform: none;'>$_('Min percentage'):</td>
+                <td>
+                    <input name='wl_min' type='number' min="0" max="100" value=$m_vals["wl_min"]>
                 </td>
             </tr>
             <tr>

--- a/weather_level_adj/weather_level_adj.py
+++ b/weather_level_adj/weather_level_adj.py
@@ -139,9 +139,15 @@ class WeatherLevelChecker(Thread):
 
                     water_adjustment = max(safe_float(options['wl_min']), min(safe_float(options['wl_max']), water_adjustment))
 
+                    #Do not run if the current temperature is below 4 Celsius
+                    if today['temp_c'] <= 4:
+                        water_adjustment = 0
+
+                    self.add_status('Current temp in C    : %.1f' % today['temp_c'])
+                    self.add_status('________________________________')
                     self.add_status('Water needed (%d days): %.1fmm' % (len(info), water_needed))
                     self.add_status('Total rainfall       : %.1fmm' % total_info['rain_mm'])
-                    self.add_status('_______________________________-')
+                    self.add_status('________________________________')
                     self.add_status('Irrigation needed    : %.1fmm' % water_left)
                     self.add_status('Weather Adjustment   : %.1f%%' % water_adjustment)
 

--- a/weather_level_adj/weather_level_adj.py
+++ b/weather_level_adj/weather_level_adj.py
@@ -139,8 +139,8 @@ class WeatherLevelChecker(Thread):
 
                     water_adjustment = max(safe_float(options['wl_min']), min(safe_float(options['wl_max']), water_adjustment))
 
-                    #Do not run if the current temperature is below 4 Celsius
-                    if today['temp_c'] <= 4:
+                    #Do not run if the current temperature is below the cutoff temperature and the option is enabled
+                    if (today['temp_c'] <= temp_cutoff) and temp_cutoff_enable:
                         water_adjustment = 0
 
                     self.add_status('Current temp in C    : %.1f' % today['temp_c'])
@@ -205,6 +205,8 @@ def options_data():
     # Defaults:
     result = {
         'auto_wl': 'off',
+        'temp_cutoff_enable': 'off',
+        'temp_cutoff': 4,
         'wl_min': 0,
         'wl_max': 200,
         'days_history': 3,

--- a/weather_level_adj/weather_level_adj.py
+++ b/weather_level_adj/weather_level_adj.py
@@ -140,7 +140,7 @@ class WeatherLevelChecker(Thread):
                     water_adjustment = max(safe_float(options['wl_min']), min(safe_float(options['wl_max']), water_adjustment))
 
                     #Do not run if the current temperature is below the cutoff temperature and the option is enabled
-                    if (today['temp_c'] <= options['temp_cutoff']) and options['temp_cutoff_enable']:
+                    if (safe_float(today['temp_c']) <= safe_float(options['temp_cutoff'])) and options["temp_cutoff_enable"] == "on":
                         water_adjustment = 0
 
                     self.add_status('Current temp in C    : %.1f' % today['temp_c'])

--- a/weather_level_adj/weather_level_adj.py
+++ b/weather_level_adj/weather_level_adj.py
@@ -140,7 +140,7 @@ class WeatherLevelChecker(Thread):
                     water_adjustment = max(safe_float(options['wl_min']), min(safe_float(options['wl_max']), water_adjustment))
 
                     #Do not run if the current temperature is below the cutoff temperature and the option is enabled
-                    if (today['temp_c'] <= temp_cutoff) and temp_cutoff_enable:
+                    if (today['temp_c'] <= options['temp_cutoff']) and options['temp_cutoff_enable']:
                         water_adjustment = 0
 
                     self.add_status('Current temp in C    : %.1f' % today['temp_c'])


### PR DESCRIPTION
Summary: Don’t run the sprinklers if the current temperature is below X degrees
Celsius.

Reasoning: I caught my sprinklers running yesterday morning when it was at freezing 0C. We have a large temperature swing throughout the day. I want the sprinklers running if it’s warm, but not if it’s too close to freezing.

I added a check for the current temperature each time the weather is retrieved. I also added an option in the GUI to enable/disable this feature along with being able to set the cutoff temperature. If it’s <= the cutoff temperature I set water_adjustment = 0 so that the sprinklers won’t run.