### PR TITLE
Add user/pass to broker login

### DIFF
--- a/mqtt/mqtt.html
+++ b/mqtt/mqtt.html
@@ -58,7 +58,6 @@ $var page: mqtt_plugin
                 <td style='text-transform: none;'>$_('MQTT Client ID'):</td>  <!--Edit-->
                 <td>${client_id}</td>
             </tr>
-
         </table>
 
     </form>

--- a/mqtt/mqtt.html
+++ b/mqtt/mqtt.html
@@ -42,6 +42,14 @@ $var page: mqtt_plugin
                 <td><input type="text" name="broker_port" value="${settings['broker_port']}"></td>
             </tr>
             <tr>
+                <td style='text-transform: none;'>$_('MQTT Broker Username'):</td>
+                <td><input type="text" name="broker_username" value="${settings['broker_username']}"></td>
+            </tr>
+            <tr>
+                <td style='text-transform: none;'>$_('MQTT Broker Password'):</td>
+                <td><input type="text" name="broker_password" value="${settings['broker_password']}"></td>
+            </tr>
+            <tr>
               <td style='text-transform: none;'>$_('MQTT Publish up/down topic'):</td>
               <td><input type="text" name="publish_up_down" value="${settings['publish_up_down']}">
               Leave blank to not publish SIP status.</td>
@@ -50,6 +58,7 @@ $var page: mqtt_plugin
                 <td style='text-transform: none;'>$_('MQTT Client ID'):</td>  <!--Edit-->
                 <td>${client_id}</td>
             </tr>
+
         </table>
 
     </form>

--- a/mqtt/mqtt.py
+++ b/mqtt/mqtt.py
@@ -25,6 +25,8 @@ _client = None
 _settings = {
     'broker_host': 'localhost',
     'broker_port': 1883,
+    'broker_username': 'user',
+    'broker_password': 'pass',
     'publish_up_down': ''
 }
 _subscriptions = {}
@@ -58,6 +60,8 @@ class save_settings(ProtectedPage):
                 port = int(qdict['broker_port'])
                 assert port > 80 and port < 65535
                 _settings['broker_port'] = port
+                _settings['broker_username'] = qdict['broker_username']
+                _settings['broker_password'] = qdict['broker_password']
                 _settings['broker_host'] = qdict['broker_host']
                 _settings['publish_up_down'] = qdict['publish_up_down']
             except:

--- a/mqtt/mqtt.py
+++ b/mqtt/mqtt.py
@@ -100,6 +100,7 @@ def get_client():
         try:
             _client = mqtt.Client(gv.sd[u'name']) # Use system name as client ID
             _client.on_message = on_message
+            _client.username_pw_set(_settings['broker_username'],_settings['broker_password'])
             _client.connect(_settings['broker_host'], _settings['broker_port'])
             if _settings['publish_up_down']:
                 _client.will_set(_settings['publish_up_down'], json.dumps("DIED"), qos=1, retain=True)


### PR DESCRIPTION
Adds user/pass to broker login.

If you do not need a user/pass it is ignored by the mqtt server.

http://www.steves-internet-guide.com/mqtt-username-password-example/
http://www.steves-internet-guide.com/wp-content/uploads/MQTT-password-examples.jpg

