### PR TITLE
Allow send mail plugin to use custom smpt servers

### DIFF
--- a/email_adj/email_adj.html
+++ b/email_adj/email_adj.html
@@ -5,13 +5,13 @@ $var page: plugins
 
 <script>
     // Initialize behaviors
-    jQuery(document).ready(function(){
+    jQuery(document).ready(function () {
 
-        jQuery("#cSubmit").click(function() {
+        jQuery("#cSubmit").click(function () {
             jQuery("#pluginForm").submit();
         });
-        jQuery("button#cCancel").click(function(){
-            window.location="/";
+        jQuery("button#cCancel").click(function () {
+            window.location = "/";
         });
 
     });
@@ -42,6 +42,28 @@ $var page: plugins
                 </td>
             </tr>
             <tr>
+                <td style='text-transform: none;'>$_('SMTP server address'):
+                    <div><small>$_('example'): smtp.gmail.com</small></div>
+                </td>
+                <td>
+                    <input name='emlserver' type='text' value=$m_vals["emlserver"]>
+                </td>
+            </tr>
+            <tr>
+                <td style='text-transform: none;'>$_('SMTP port'):
+                    <div><small>$_('example'): 587</small></div>
+                </td>
+                <td>
+                    <input name='emlport' type='text' value=$m_vals["emlport"]>
+                </td>
+            </tr>
+             <td style='text-transform: none;'>$_('Use SMTP username as sender'):
+              <div><small>$_('Some smpt providers prohibit to use another sender than the same mail user')</small></div>
+             </td>
+                <td>
+                    <input name='emlsender' type='checkbox' ${" checked" if m_vals['emlsender'] == "on" else ""}>
+                </td>
+            <tr>
                 <td style='text-transform: none;'>$_('SMTP username'):
                     <div><small>$_('Your e-mail password')</small></div>
                 </td>
@@ -71,10 +93,15 @@ $var page: plugins
             </tr>
         </table>
     </form>
+
 </div>
 <div id="controls">
-    <button id="cSubmit" class="submit"><b>Submit</b></button>
-    <button id="cCancel" class="cancel danger">Cancel</button>
+    <button id="cSubmit" class="submit"><b>$_('Submit')</b></button>
+    <button id="cCancel" class="cancel danger">$_('Cancel')</button>
 </div>
 
+<form id="testEmail" action="/uemltest" method="get">
+    <button class="submit"><b>$_('Send test email')</b></button>
+
+</form>
 

--- a/email_adj/email_adj.html
+++ b/email_adj/email_adj.html
@@ -18,49 +18,53 @@ $var page: plugins
 </script>
 
 <div id="plugin">
-    <div class="title">Email adjustments</div>
-    <p>This plugin can send E-mails. For this plugin you need a GMail account as provider.</p>
+    <div class="title">$_('Email adjustments')</div>
+    <p>$_('This plugin can send E-mails. For this plugin you need an e-mail smtp account as provider.')</p>
     <form id="pluginForm" action="/uemla" method="get">
         <table class="optionList">
             <tr>
-                <td style='text-transform: none;'>Send email with file log.csv after power on:</td>
+                <td style='text-transform: none;'>$_('Send email with file log.csv after power on'):</td>
                 <td>
-                    <input name='emllog' type='checkbox'${" checked" if m_vals['emllog'] == "on" else ""}>   
+                    <input name='emllog' type='checkbox' ${" checked" if m_vals['emllog'] == "on" else ""}>
                 </td>
             </tr>
             <tr>
-                <td style='text-transform: none;'>Send email if rain is detected:</td>
+                <td style='text-transform: none;'>$_('Send email if rain is detected'):</td>
                 <td>
-                    <input name='emlrain' type='checkbox'${" checked" if m_vals['emlrain'] == "on" else ""}>   
+                    <input name='emlrain' type='checkbox' ${" checked" if m_vals['emlrain'] == "on" else ""}>
                 </td>
             </tr>
 
             <tr>
-                <td style='text-transform: none;'>Sends email if program has run:</td>
+                <td style='text-transform: none;'>$_('Sends email if program has run'):</td>
                 <td>
-                    <input name='emlrun' type='checkbox'${" checked" if m_vals['emlrun'] == "on" else ""}> 
+                    <input name='emlrun' type='checkbox' ${" checked" if m_vals['emlrun'] == "on" else ""}>
                 </td>
             </tr>
             <tr>
-                <td style='text-transform: none;'>Your GMail username:</td>
+                <td style='text-transform: none;'>$_('SMTP username'):
+                    <div><small>$_('Your e-mail password')</small></div>
+                </td>
                 <td>
                     <input name='emlusr' type='text' value=$m_vals["emlusr"]>
                 </td>
             </tr>
             <tr>
-                <td style='text-transform: none;'>Your GMail password:</td>
+                <td style='text-transform: none;'>$_('SMTP password'):
+                    <div><small>$_('Your e-mail password')</small></div>
+                </td>
                 <td>
                     <input name='emlpwd' type='password' value=$m_vals["emlpwd"]>
                 </td>
             </tr>
             <tr>
-                <td style='text-transform: none;'>Send mail to:</td>
+                <td style='text-transform: none;'>$_('Send mail to'):</td>
                 <td>
                     <input name='emladr' type='text' value=$m_vals["emladr"]>
                 </td>
             </tr>
             <tr>
-                <td style='text-transform: none;'>Status:</td>
+                <td style='text-transform: none;'>$_('Status'):</td>
                 <td>
                     <textarea style="font-family: monospace;" rows="7" cols="35" readonly>$m_vals['status']</textarea>
                 </td>
@@ -72,5 +76,5 @@ $var page: plugins
     <button id="cSubmit" class="submit"><b>Submit</b></button>
     <button id="cCancel" class="cancel danger">Cancel</button>
 </div>
-                                  
-                     
+
+


### PR DESCRIPTION
Give the opportunity to use other smtp providers (yahoo, microsoft etc) , by publishing some configurations

For my text I used yahoo. 
It needs to create and use an app password and the sender must be the same as the email username

Plus change the literals to translatable