### PR TITLE
Apply MQTT setting changes without SIP restart and reporting

### DIFF
--- a/mqtt/mqtt.py
+++ b/mqtt/mqtt.py
@@ -139,7 +139,7 @@ def apply_new_mqtt_settings(previous):
     ):
         status_topic_change = True
 
-    server_changed = False
+    server_change = False
     for i in [
         u"broker_port",
         u"broker_username",


### PR DESCRIPTION
Apply new MQTT settings without restarting SIP. If there is an active MQTT session
- unpublish old status topic
- close and restart MQTT server session
- publish new status topic (if changed)

Also add reporting signal on MQTT settings change.
