### PR TITLE
- Add plugin to control valves with shelly.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "advance_control"]
+	path = advance_control
+	url = git@github.com:PedroFRCSantos/SIP_extension_advance_control.git


### PR DESCRIPTION
Add first version of advance control to use direct HTTP commands from shelly devices.
I use git sub-modules, if not working correctly I can add the code itself.
Maybe reference to last TAG version is better?