### PR TITLE
Monthly adjust per station

### DIFF
--- a/monthly_adjust_per_station/README.md
+++ b/monthly_adjust_per_station/README.md
@@ -1,0 +1,13 @@
+# Monthly Adjust per Station Plugin
+
+Alter the amount of water the station delivers by adjusting the
+watering time.
+
+Values can be entered per station per month to indicate
+the % adjustment to be applied to the watering time.
+
+If no value is entered for the station/month the value set in the
+"Default Adjustment" is used.
+
+If the "Default Adjustment" is not set then
+the plugin will take no action for the station/month.

--- a/monthly_adjust_per_station/README.md
+++ b/monthly_adjust_per_station/README.md
@@ -1,13 +1,21 @@
 # Monthly Adjust per Station Plugin
 
 Alter the amount of water the station delivers by adjusting the
-watering time.
+watering time. This plugin allows a more fine grained level of control
+than the water level setting on the home page.
 
-Values can be entered per station per month to indicate
+The plugin will only have an effect on schedules started by programs
+triggered automatically and will ignore schedules started with RUN
+NOW.
+
+Adjustment levels can be entered per station per month to indicate
 the % adjustment to be applied to the watering time.
 
-If no value is entered for the station/month the value set in the
-"Default Adjustment" is used.
-
-If the "Default Adjustment" is not set then
+If no value is entered for the station/month the value set in
+"Default Adjustment" is used. If the "Default Adjustment" is not set then
 the plugin will take no action for the station/month.
+
+Limitations:
+- The plugin does not currently respect the option "Ignore Plugin
+  adjustments", mainly because I do not understand how to implement
+  the validation.

--- a/monthly_adjust_per_station/monthly_adjust_per_station-docs.html
+++ b/monthly_adjust_per_station/monthly_adjust_per_station-docs.html
@@ -5,21 +5,29 @@
 <html>
 <head>
   <meta http-equiv="content-type" content="text/html; charset="utf-8">
-  <title>Monthlu Adjust per Station Docs</TITLE>
+  <title>Monthly Adjust per Station Docs</TITLE>
 </head>
 <body lang="en-us" bgcolor="#ffffff" dir="LTR" style="border: none; padding: 0in">
 <h1>Monthly Adjust per Station Plugin</h1>
 
 <p>Alter the amount of water the station delivers by adjusting the
-watering time.</p>
+watering time. This plugin allows a more fine grained level of control
+than the water level setting on the home page.</p>
 
-<p>Values can be entered per station per month to indicate
+<p>The plugin will only have an effect on schedules started by programs
+triggered automatically and will ignore schedules started with RUN
+NOW.</p>
+
+<p>Adjustment levels can be entered per station per month to indicate
 the % adjustment to be applied to the watering time.</p>
 
-<p>If no value is entered for the station/month the value set in the
-"Default Adjustment" is used.</p>
-
-<p>If the "Default Adjustment" is not set then
+<p>If no value is entered for the station/month the value set in
+"Default Adjustment" is used. If the "Default Adjustment" is not set then
 the plugin will take no action for the station/month.</p>
+
+<p>Limitations:
+- The plugin does not currently respect the option "Ignore Plugin
+  adjustments", mainly because I do not understand how to implement
+  the validation.</p>
 </body>
 </html>

--- a/monthly_adjust_per_station/monthly_adjust_per_station-docs.html
+++ b/monthly_adjust_per_station/monthly_adjust_per_station-docs.html
@@ -1,0 +1,25 @@
+<!DOCTYPE HTML>
+<!-- Auto genwerated using markdown2 README.md --extras tables > monthly_adjust_per_station-docs.html -->
+<html>
+<!doctype html>
+<html>
+<head>
+  <meta http-equiv="content-type" content="text/html; charset="utf-8">
+  <title>Monthlu Adjust per Station Docs</TITLE>
+</head>
+<body lang="en-us" bgcolor="#ffffff" dir="LTR" style="border: none; padding: 0in">
+<h1>Monthly Adjust per Station Plugin</h1>
+
+<p>Alter the amount of water the station delivers by adjusting the
+watering time.</p>
+
+<p>Values can be entered per station per month to indicate
+the % adjustment to be applied to the watering time.</p>
+
+<p>If no value is entered for the station/month the value set in the
+"Default Adjustment" is used.</p>
+
+<p>If the "Default Adjustment" is not set then
+the plugin will take no action for the station/month.</p>
+</body>
+</html>

--- a/monthly_adjust_per_station/monthly_adjust_per_station.html
+++ b/monthly_adjust_per_station/monthly_adjust_per_station.html
@@ -1,0 +1,93 @@
+$def with(settings)
+
+$var title: $_('Monthly Adjust per Station')
+$var page: monthly_adjust_per_station
+<script>
+    // Initialize behaviors
+    jQuery(document).ready(function(){
+
+        jQuery("#cSubmit").click(function() {
+            jQuery("#pluginForm").submit();
+        });
+        jQuery("button#cCancel").click(function(){
+            window.location="/";
+        });
+
+        jQuery("button#docButton").click(function(){
+            window.open("static/docs/plugins/monthly_adjust_per_station-docs.html", "_blank");
+        });
+
+        function pretty() {
+            alert("ready");
+            jQuery("table#st_mon tr").each(function(rowIndex) {
+                $$(this).find("td").each(function(cellIndex) {
+                    console.log("Row " + rowIndex + ", cell " + cellIndex + ": " + $$(this).find("input[type=number]").val());
+                });
+            }); }
+        // pretty();
+    });
+</script>
+
+<style>
+table, th, td {
+  border: 1px solid lightgray;
+  border-collapse: collapse;
+  padding: 5px;
+}
+
+input[type='number']{
+    width: 2.8em;
+}
+</style>
+
+<div id="plugin">
+  <div class="title">Monthly Adjust per Station
+    <button class="execute" id="docButton" type="button" >$_('Help')</button>
+  </div>
+
+
+  <form id="pluginForm" action="/monthly_adjust_per_station-save" method="get">
+    <p>
+      Default adjustment:
+      <input type="number" min="0" id="default" name="default"
+           value="${settings[u"default"] if u"default" in settings and settings[u"default"] != u"" else u"100"}"
+           onkeypress="if (isNaN(String.fromCharCode(event.keyCode))) return false;"> %
+    </p>
+    </br>
+
+    <table id="st_mon" class="st_mon" class="optionList">
+      <tr>
+        <th class="columnName">
+          <div>$_(u'Station')</div>
+        </th>
+        $for heading in ['Jan', 'Feb', 'Mar', 'Apr', 'Mai', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec']:
+          <th class="columnName">
+            <div>$heading</div>
+          </th>
+
+      </tr>
+      $#{settings}
+      $for bid in range(0,gv.sd['nbrd']):
+        $for s in range(0,8):
+          $ sid = (bid * 8) + s;
+          $ s_sid = str(sid);
+          <tr>
+            <td class="stationNumber">${gv.snames[sid]}</td>
+            $for mon in range(1,13):
+            $ s_mon = str(mon)
+            <td
+              bgcolor="${settings[u"c_st_mon_" + s_sid + u"_" + s_mon] if u"c_st_mon_" + s_sid + u"_" + s_mon in settings else u""}">
+              <input type="number" min="0" id="st_mon_${sid}_${mon}" name="st_mon_${sid}_${mon}"
+                     value="${settings[u"st_mon_" + s_sid + u"_" + s_mon] if u"st_mon_" + s_sid + u"_" + s_mon in settings else u""}"
+                     onkeypress="if (isNaN(String.fromCharCode(event.keyCode))) return false;"> %
+            </td>
+          </tr>
+    </table>
+
+    </form>
+
+<div class="controls">
+    <button id="cSubmit" class="submit"><b>$_('Submit')</b></button>
+    <button id="cCancel" class="cancel danger">$_('Cancel')</button>
+</div>
+</div>

--- a/monthly_adjust_per_station/monthly_adjust_per_station.html
+++ b/monthly_adjust_per_station/monthly_adjust_per_station.html
@@ -3,41 +3,49 @@ $def with(settings)
 $var title: $_('Monthly Adjust per Station')
 $var page: monthly_adjust_per_station
 <script>
-    // Initialize behaviors
-    jQuery(document).ready(function(){
+  // Initialize behaviors
+  jQuery(document).ready(function(){
 
-        jQuery("#cSubmit").click(function() {
-            jQuery("#pluginForm").submit();
-        });
-        jQuery("button#cCancel").click(function(){
-            window.location="/";
-        });
+      jQuery("#cSubmit").click(function() {
+          jQuery("#pluginForm").submit();
+      });
+      jQuery("button#cCancel").click(function(){
+          window.location="/";
+      });
 
-        jQuery("button#docButton").click(function(){
-            window.open("static/docs/plugins/monthly_adjust_per_station-docs.html", "_blank");
-        });
+      jQuery("button#docButton").click(function(){
+          window.open("static/docs/plugins/monthly_adjust_per_station-docs.html", "_blank");
+      });
 
-        function pretty() {
-            alert("ready");
-            jQuery("table#st_mon tr").each(function(rowIndex) {
-                $$(this).find("td").each(function(cellIndex) {
-                    console.log("Row " + rowIndex + ", cell " + cellIndex + ": " + $$(this).find("input[type=number]").val());
-                });
-            }); }
-        // pretty();
-    });
+      function pretty() {
+          jQuery("table#st_mon tr").each(function(rowIndex) {
+              $$(this).find("td").each(function(cellIndex) {
+                  console.log("Row " + rowIndex + ", cell " + cellIndex + ": " + $$(this).find("input[type=number]").val());
+              });
+          }); }
+      // pretty();
+  });
 </script>
 
 <style>
-table, th, td {
-  border: 1px solid lightgray;
-  border-collapse: collapse;
-  padding: 5px;
-}
+  td, input[type="checkbox"]  {
+      text-align: center;
+      vertical-align: middle;
+  }
 
-input[type='number']{
-    width: 2.8em;
-}
+  td, input[type="number"]  {
+      white-space: nowrap;
+  }
+
+  table, th, td {
+      border: 1px solid lightgray;
+      border-collapse: collapse;
+      padding: 5px;
+  }
+
+  input[type='number']{
+      width: 2.77em;
+  }
 </style>
 
 <div id="plugin">
@@ -45,25 +53,27 @@ input[type='number']{
     <button class="execute" id="docButton" type="button" >$_('Help')</button>
   </div>
 
-
   <form id="pluginForm" action="/monthly_adjust_per_station-save" method="get">
     <p>
       Default adjustment:
       <input type="number" min="0" id="default" name="default"
-           value="${settings[u"default"] if u"default" in settings and settings[u"default"] != u"" else u"100"}"
-           onkeypress="if (isNaN(String.fromCharCode(event.keyCode))) return false;"> %
+             value="${settings[u"default"] if u"default" in settings and settings[u"default"] != u"" else u"100"}"
+             onkeypress="if (isNaN(String.fromCharCode(event.keyCode))) return false;"> %
     </p>
     </br>
 
-    <table id="st_mon" class="st_mon" class="optionList">
+    <table id="st_mon" class="optionList">
       <tr>
         <th class="columnName">
           <div>$_(u'Station')</div>
         </th>
+        <th class="columnName">
+          <div>$_(u'Enable')</div>
+        </th>
         $for heading in ['Jan', 'Feb', 'Mar', 'Apr', 'Mai', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec']:
-          <th class="columnName">
-            <div>$heading</div>
-          </th>
+        <th class="columnName">
+          <div>$heading</div>
+        </th>
 
       </tr>
       $#{settings}
@@ -72,7 +82,12 @@ input[type='number']{
           $ sid = (bid * 8) + s;
           $ s_sid = str(sid);
           <tr>
-            <td class="stationNumber">${gv.snames[sid]}</td>
+            <td class="stationNumber">${gv.snames[sid]}
+            </td>
+            <td>
+              <input type="checkbox" id="enable_${sid}" name="enable_${sid}"
+                     ${"checked" if "enable_" + s_sid in settings else ""}>
+            </td>
             $for mon in range(1,13):
             $ s_mon = str(mon)
             <td
@@ -83,11 +98,10 @@ input[type='number']{
             </td>
           </tr>
     </table>
-
-    </form>
-
-<div class="controls">
+  </form>
+  </br>
+  <div class="controls">
     <button id="cSubmit" class="submit"><b>$_('Submit')</b></button>
     <button id="cCancel" class="cancel danger">$_('Cancel')</button>
-</div>
+  </div>
 </div>

--- a/monthly_adjust_per_station/monthly_adjust_per_station.manifest
+++ b/monthly_adjust_per_station/monthly_adjust_per_station.manifest
@@ -1,0 +1,9 @@
+A bare bones plugin designed to be used as a starting point for writing plugins.
+
+##### List all plugin files below preceded by a blank line [file_name.ext path] relative to SIP directory #####
+
+monthly_adjust_per_station.py plugins
+monthly_adjust_per_station.html templates
+monthly_adjust_per_station-docs.html static/docs/plugins
+monthly_adjust_per_station.json data (generated)
+monthly_adjust_per_station.manifest plugins/manifests

--- a/monthly_adjust_per_station/monthly_adjust_per_station.py
+++ b/monthly_adjust_per_station/monthly_adjust_per_station.py
@@ -33,11 +33,15 @@ urls.extend([
 gv.plugin_menu.append([_("Monthly Adjust per Station"), "/monthly_adjust_per_station"])
 
 
-ADJUSTMENT_COLORS = ["#e8f4ea", "#e0f0e3", "#d2e7d6", "#c8e1cc", "#b8d8be"]
+# ADJUSTMENT_COLORS = ["#e8f4ea", "#e0f0e3", "#d2e7d6", "#c8e1cc", "#b8d8be"]
+ADJUSTMENT_COLORS = ["#d4ffc5", "#b2eb99", "#87ca6a", "#6bac50", "#54883d"]
 station_settings = {}
 
 
 def validate_int(int_list):
+    """Validate a list of integer strings and return result as a
+    tuple. Invalid integers are returned as None
+    """
     validated_list = []
 
     for index in range(len(int_list)):
@@ -49,52 +53,61 @@ def validate_int(int_list):
     return tuple(validated_list)
 
 
-def notify_stations_scheduled(station, **kw):
-    """todo"""
+def notify_station_scheduled(station, **kw):
+    """Apply the defined adjustment to the schedule running on the
+    station if applicable (Not RUN NOW, enabled)
+    """
 
-    print(station_settings)
-    print(f"=== Before {gv.rs}")
     ts = datetime.datetime.fromtimestamp(gv.now)
     cur_month = ts.month
+    station_index = station - 1
 
-    for station_index in range(0, len(gv.rs)):
-        if gv.rs[station_index][2] > 0:
-            st_mon_key = f"st_mon_{station_index}_{cur_month}"
+    # TODO honor "Ignore Plugin adjustments"
 
-            if st_mon_key in station_settings:
-                (adjustment,) = validate_int(
+    if gv.rn:
+        # Skip RUN NOW schedules
+        return
+
+    st_enable_key = f"enable_{station_index}"
+    st_mon_key = f"st_mon_{station_index}_{cur_month}"
+
+    if st_enable_key not in station_settings:
+        return
+
+    if st_mon_key in station_settings:
+        (adjustment,) = validate_int(
+            [
+                station_settings[st_mon_key],
+            ]
+        )
+
+        if adjustment is None:
+            if "default" not in station_settings:
+                return
+            else:
+                (default,) = validate_int(
                     [
-                        station_settings[st_mon_key],
+                        station_settings["default"],
                     ]
                 )
-                print(adjustment)
+                if default is None or default == 100:
+                    return
+                else:
+                    adjustment = default
 
-                if adjustment is None:
-                    if "default" not in station_settings:
-                        return
-                    else:
-                        (default,) = validate_int(
-                            [
-                                station_settings["default"],
-                            ]
-                        )
-                        if default is None:
-                            return
-                        else:
-                            adjustment = default
+        if adjustment == 100:
+            # Nothing to adjust
+            return
 
-                duration = gv.rs[station_index][2]
+        duration = gv.rs[station_index][2]
 
-                # duration = round(duration * adjustment / 100, 1)
-                # duration = round(duration * adjustment / 100)
-                duration = math.ceil(duration * adjustment / 100)
-                gv.rs[station_index][1] = gv.rs[station_index][0] + duration
-                gv.rs[station_index][2] = duration
-    print(f"=== After {gv.rs}")
+        duration = math.ceil(duration * adjustment / 100)
+        gv.rs[station_index][1] = gv.rs[station_index][0] + duration
+        gv.rs[station_index][2] = duration
 
 
-scheduled_signal = signal("stations_scheduled")
-scheduled_signal.connect(notify_stations_scheduled)
+scheduled_signal = signal("station_scheduled")
+scheduled_signal.connect(notify_station_scheduled)
 
 
 def load_settings():
@@ -106,7 +119,8 @@ def load_settings():
         ) as f:  # Read settings from json file if it exists
             station_settings = json.load(f)
 
-    except IOError:  # If file does not exist return empty value
+    except IOError:
+        # If file does not exist return empty value
         station_settings = {}
 
 
@@ -116,11 +130,9 @@ class get_settings(ProtectedPage):
     """
 
     def GET(self):
-        # load_settings()
 
-        return template_render.monthly_adjust_per_station(
-            station_settings
-        )  # open settings page
+        # open settings page
+        return template_render.monthly_adjust_per_station(station_settings)
 
 
 class save_settings(ProtectedPage):
@@ -130,20 +142,16 @@ class save_settings(ProtectedPage):
     CheckBoxes only appear in qdict if they are checked.
     """
 
-    def GET(self):
+    def set_cell_decoration(self):
+        """Set color of the cells containing adjustments using a
+        gradient scheme."""
+
         global station_settings
+        min_adj = math.inf
+        max_adj = 0
+        adjustments = {}
 
-        # Dictionary of values returned as query string from settings page.
-        qdict = web.input()
-
-        station_settings = qdict
-
-        # Set color of adjustments
-        for st in range(0, len(gv.rs)):
-            min_adj = math.inf
-            max_adj = 0
-            adjustments = {}
-
+        for st in range(0, len(gv.rs)):  # Number of stations
             for mon in range(1, 13):  # 12 months of the year
                 st_mon_key = f"st_mon_{st}_{mon}"
                 (cur_adj,) = validate_int([station_settings[st_mon_key]])
@@ -157,19 +165,29 @@ class save_settings(ProtectedPage):
 
                     adjustments[st_mon_key] = cur_adj
 
-            if len(adjustments) > 0:
-                old_range = max_adj - min_adj
+        if len(adjustments) > 0:
+            old_range = max_adj - min_adj
 
-                for st_mon_key in adjustments.keys():
-                    cur_adj = adjustments[st_mon_key]
+            for st_mon_key in adjustments.keys():
+                cur_adj = adjustments[st_mon_key]
 
-                    if old_range == 0:
-                        color_idx = 0
-                    else:
-                        # Distribute adjustments evenly in range 0-4
-                        color_idx = math.trunc((cur_adj - min_adj) * 4.9 / old_range)
+                if old_range == 0:
+                    color_idx = 0
+                else:
+                    # Distribute adjustments evenly in range 0-4
+                    color_idx = math.trunc((cur_adj - min_adj) * 4.9 / old_range)
 
-                    station_settings[f"c_{st_mon_key}"] = ADJUSTMENT_COLORS[color_idx]
+                station_settings[f"c_{st_mon_key}"] = ADJUSTMENT_COLORS[color_idx]
+
+    def GET(self):
+        global station_settings
+
+        # Dictionary of values returned as query string from settings page.
+        qdict = web.input()
+
+        station_settings = qdict
+
+        save_settings.set_cell_decoration(self)
 
         with open("./data/monthly_adjust_per_station.json", "w") as f:
             json.dump(station_settings, f)

--- a/monthly_adjust_per_station/monthly_adjust_per_station.py
+++ b/monthly_adjust_per_station/monthly_adjust_per_station.py
@@ -1,0 +1,182 @@
+# !/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+# standard library imports
+import json  # for working with data file
+from threading import Thread
+from time import sleep
+
+# local module imports
+from blinker import signal
+import gv  # Get access to SIP's settings
+from sip import template_render  #  Needed for working with web.py templates
+from urls import urls  # Get access to SIP's URLs
+import web  # web.py framework
+from webpages import ProtectedPage  # Needed for security
+from webpages import showInFooter  # Enable plugin to display readings in UI footer
+from webpages import showOnTimeline  # Enable plugin to display station data on timeline
+
+
+import datetime
+import math
+
+# Add new URLs to access classes in this plugin.
+# fmt: off
+urls.extend([
+    u"/monthly_adjust_per_station", u"plugins.monthly_adjust_per_station.get_settings",
+    u"/monthly_adjust_per_station-save", u"plugins.monthly_adjust_per_station.save_settings"
+
+    ])
+# fmt: on
+
+# Add this plugin to the PLUGINS menu ["Menu Name", "URL"], (Optional)
+gv.plugin_menu.append([_("Monthly Adjust per Station"), "/monthly_adjust_per_station"])
+
+
+ADJUSTMENT_COLORS = ["#e8f4ea", "#e0f0e3", "#d2e7d6", "#c8e1cc", "#b8d8be"]
+station_settings = {}
+
+
+def validate_int(int_list):
+    validated_list = []
+
+    for index in range(len(int_list)):
+        try:
+            validated_list.append(int(int_list[index]))
+        except (TypeError, ValueError):
+            validated_list.append(None)
+
+    return tuple(validated_list)
+
+
+def notify_stations_scheduled(station, **kw):
+    """todo"""
+
+    print(station_settings)
+    print(f"=== Before {gv.rs}")
+    ts = datetime.datetime.fromtimestamp(gv.now)
+    cur_month = ts.month
+
+    for station_index in range(0, len(gv.rs)):
+        if gv.rs[station_index][2] > 0:
+            st_mon_key = f"st_mon_{station_index}_{cur_month}"
+
+            if st_mon_key in station_settings:
+                (adjustment,) = validate_int(
+                    [
+                        station_settings[st_mon_key],
+                    ]
+                )
+                print(adjustment)
+
+                if adjustment is None:
+                    if "default" not in station_settings:
+                        return
+                    else:
+                        (default,) = validate_int(
+                            [
+                                station_settings["default"],
+                            ]
+                        )
+                        if default is None:
+                            return
+                        else:
+                            adjustment = default
+
+                duration = gv.rs[station_index][2]
+
+                # duration = round(duration * adjustment / 100, 1)
+                # duration = round(duration * adjustment / 100)
+                duration = math.ceil(duration * adjustment / 100)
+                gv.rs[station_index][1] = gv.rs[station_index][0] + duration
+                gv.rs[station_index][2] = duration
+    print(f"=== After {gv.rs}")
+
+
+scheduled_signal = signal("stations_scheduled")
+scheduled_signal.connect(notify_stations_scheduled)
+
+
+def load_settings():
+    global station_settings
+
+    try:
+        with open(
+            "./data/monthly_adjust_per_station.json", "r"
+        ) as f:  # Read settings from json file if it exists
+            station_settings = json.load(f)
+
+    except IOError:  # If file does not exist return empty value
+        station_settings = {}
+
+
+class get_settings(ProtectedPage):
+    """
+    Load an html page for entering plugin settings.
+    """
+
+    def GET(self):
+        # load_settings()
+
+        return template_render.monthly_adjust_per_station(
+            station_settings
+        )  # open settings page
+
+
+class save_settings(ProtectedPage):
+    """
+    Save user input to json file.
+    Will create or update file when SUBMIT button is clicked
+    CheckBoxes only appear in qdict if they are checked.
+    """
+
+    def GET(self):
+        global station_settings
+
+        # Dictionary of values returned as query string from settings page.
+        qdict = web.input()
+
+        station_settings = qdict
+
+        # Set color of adjustments
+        for st in range(0, len(gv.rs)):
+            min_adj = math.inf
+            max_adj = 0
+            adjustments = {}
+
+            for mon in range(1, 13):  # 12 months of the year
+                st_mon_key = f"st_mon_{st}_{mon}"
+                (cur_adj,) = validate_int([station_settings[st_mon_key]])
+
+                # Determine max and min value in range for each station
+                if cur_adj is not None:
+                    if cur_adj < min_adj:
+                        min_adj = cur_adj
+                    if cur_adj > max_adj:
+                        max_adj = cur_adj
+
+                    adjustments[st_mon_key] = cur_adj
+
+            if len(adjustments) > 0:
+                old_range = max_adj - min_adj
+
+                for st_mon_key in adjustments.keys():
+                    cur_adj = adjustments[st_mon_key]
+
+                    if old_range == 0:
+                        color_idx = 0
+                    else:
+                        # Distribute adjustments evenly in range 0-4
+                        color_idx = math.trunc((cur_adj - min_adj) * 4.9 / old_range)
+
+                    station_settings[f"c_{st_mon_key}"] = ADJUSTMENT_COLORS[color_idx]
+
+        with open("./data/monthly_adjust_per_station.json", "w") as f:
+            json.dump(station_settings, f)
+
+        # Return user to plugin page
+        raise web.seeother("/monthly_adjust_per_station")
+
+
+#  Run when plugin is loaded
+load_settings()


### PR DESCRIPTION
Alter the amount of water the station delivers by adjusting the watering time. This plugin allows a more fine grained level of control than the water level setting on the home page.

The plugin will only have an effect on schedules started by programs triggered automatically and will ignore schedules started with RUN NOW.

Adjustment levels can be entered per station per month to indicate the % adjustment to be applied to the watering time.

If no value is entered for the station/month the value set in "Default Adjustment" is used. If the "Default Adjustment" is not set then the plugin will take no action for the station/month.