### PR TITLE
add hour multiplier for weather plugin

### DIFF
--- a/weather_level_adj/weather_level_adj.py
+++ b/weather_level_adj/weather_level_adj.py
@@ -571,7 +571,7 @@ def history_info(obj, curr_conditions, options):
 
     path = u"./data/weather_level_history"
     i = 1
-    count = int(options[u"days_history"])
+    count = int(options[u"days_history"])*24
     for filename in sorted(os.listdir(path)):
         tmp = re.split("_|-", filename)
         if tmp[0] == u"history":

--- a/weather_level_adj/weather_level_adj.py
+++ b/weather_level_adj/weather_level_adj.py
@@ -572,7 +572,7 @@ def history_info(obj, curr_conditions, options):
     path = u"./data/weather_level_history"
     i = 1
     count = int(options[u"days_history"])*24
-    for filename in sorted(os.listdir(path)):
+    for filename in sorted(os.listdir(path), reverse=True):
         tmp = re.split("_|-", filename)
         if tmp[0] == u"history":
             tmp.pop(0)


### PR DESCRIPTION
this plug in gets the current weather every hour on the hour and saves it to a history file. there is a varable "count" set by the number of "History days used" but it is decremented by reading a history file and which is 1 per hour. a simple fix is to mutiply the value by 24.

I noticed this because i am reading the history files into a Postgres DB and I never had an entry for rain so i began investigating and I only had 3 history files (my setting was for 3 days of history)  and they were for the first 3 hours of the current day.

after making this change i now have one for each hour

<img width="704" alt="image" src="https://github.com/user-attachments/assets/f552cca3-9742-469f-82cb-d17c76eb1f96">

Dan this is an amazing project 👍 